### PR TITLE
APT-237: Disabling clang-tidy checks not valid in our target CPU archs

### DIFF
--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -1,4 +1,4 @@
-Checks:             '*,-abseil*,-fuchsia*,-llvm-header-guard,-modernize-use-trailing-return-type,-google-runtime-references,-llvmlibc-*,-bugprone-easily-swappable-parameters,-android-cloexec-socket,-readability-function-cognitive-complexity,-misc-no-recursion'
+Checks:             '*,-abseil*,-altera*,-fuchsia*,-llvmlibc-*,-llvm-header-guard,-modernize-use-trailing-return-type,-google-runtime-references,-bugprone-easily-swappable-parameters,-android-cloexec-socket,-readability-function-cognitive-complexity,-misc-no-recursion'
 WarningsAsErrors:   '*'
 FormatStyle:        file
 CheckOptions:


### PR DESCRIPTION
Newest versions of clang-tidy, as found in Ubuntu 22.04, contain warnings which are invalid for our target architectures - they are Altera specific (see https://en.wikipedia.org/wiki/Altera). Disabling them here to avoid many false positives in newer versions of clang-tidy.