### PR TITLE
C++-14 -> C++-17 for safety critical applications, following 2023 version of MISRA standard

### DIFF
--- a/cpp/cmake/StandardConfig.cmake
+++ b/cpp/cmake/StandardConfig.cmake
@@ -148,11 +148,12 @@ function(StandardConfig config_type)
 
   # Common C++ settings
   if(SAFETY_CRITICAL)
+    # As defined by MISRA 2023 (https://misra.org.uk/misra-cpp2023-released-including-hardcopy/)
     set(CMAKE_CXX_STANDARD
-        14                # As defined by Autosar
+        17
         PARENT_SCOPE)
     set(CMAKE_C_STANDARD
-        99                # As defined by MISRA
+        99
         PARENT_SCOPE)
   else()
     set(CMAKE_CXX_STANDARD


### PR DESCRIPTION
As in 2023, MISRA migrated from C++-14 to C++-17, and some of our dependencies already rely on C++-17 (Fast-DDS record/replay).