### PR TITLE
Bugfix: Conan.cmake assumed build directory to be always ${source}/build which is not always the case

### DIFF
--- a/cpp/cmake/Conan.cmake
+++ b/cpp/cmake/Conan.cmake
@@ -2,15 +2,27 @@ cmake_minimum_required(VERSION 3.10)
 
 # Release by default
 if(NOT CMAKE_BUILD_TYPE)
-  message(STATUS "Setting build type to 'Release' as none was specified.")
-  set(CMAKE_BUILD_TYPE
-      "Release"
-      CACHE STRING "Choose the type of build." FORCE)
+    message(STATUS "Setting build type to 'Release' as none was specified.")
+    set(CMAKE_BUILD_TYPE
+        "Release"
+        CACHE STRING "Choose the type of build." FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
-message(STATUS "Executing command: conan install .. --settings=build_type=${CMAKE_BUILD_TYPE} --build=missing -c tools.system.package_manager:mode=install")
-execute_process(COMMAND conan install .. --settings=build_type=${CMAKE_BUILD_TYPE} --build=missing -c tools.system.package_manager:mode=install
-                        RESULT_VARIABLE return_code
-                        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build")
+message(STATUS "Executing conan install...")
+execute_process(
+    COMMAND conan install
+        --settings "build_type=${CMAKE_BUILD_TYPE}"
+        --output-folder "${CMAKE_BINARY_DIR}"
+        --conf "tools.system.package_manager:mode=install"
+        --conf "tools.cmake.cmake_layout:build_folder=."
+        --conf "tools.cmake.cmaketoolchain:generator=${CMAKE_GENERATOR}"
+        --build missing
+        "${CMAKE_SOURCE_DIR}"
+    RESULT_VARIABLE CONAN_RETURN_CODE
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
 
-set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/build/${CMAKE_BUILD_TYPE}/generators/conan_toolchain.cmake")
+if(CONAN_RETURN_CODE AND NOT CONAN_RETURN_CODE EQUAL "0")
+    message(FATAL_ERROR "conan install failed: ${CONAN_RETURN_CODE}")
+endif(CONAN_RETURN_CODE AND NOT CONAN_RETURN_CODE EQUAL "0")
+
+set(CMAKE_TOOLCHAIN_FILE "${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/generators/conan_toolchain.cmake")


### PR DESCRIPTION
I've made it so it supports arbitrary build folders, while when then build folder is usual ${source}/build it works exactly as it used to (I checked it).

It also uses the same CMake generator as the parent project, making it compatible with VSCode without additional manual conan config changes.