### PR TITLE
Explicitly specify binary directory

### DIFF
--- a/cpp/cmake/StandardConfig.cmake
+++ b/cpp/cmake/StandardConfig.cmake
@@ -209,7 +209,7 @@ function(StandardConfig config_type)
       set(ENABLE_CHECK_FORMAT OFF)
     else(NOT EXISTS "${FORMAT_CMAKE_PATH}")
       set(FORMAT_SKIP_CMAKE YES CACHE BOOL "" FORCE)
-      add_subdirectory("${FORMAT_CMAKE_PATH}" EXCLUDE_FROM_ALL)
+      add_subdirectory("${FORMAT_CMAKE_PATH}" "${CMAKE_BINARY_DIR}/format_cmake" EXCLUDE_FROM_ALL)
 
       # Automatically enable clang-format checks if STATIC_ANALYSIS is turned on
       if(STATIC_ANALYSIS)


### PR DESCRIPTION
JIRA issue: APT-7466

[CMake documentation](https://cmake.org/cmake/help/v3.3/command/add_subdirectory.html) says that if build_dir is ommited source_dir is being used, so there should be no unexpected effects.

However without explicitly defining it building conan package fails (see bug in JIRA).