### PR TITLE
Add /EHsc to MSVC compile options in StandardConfig

### DIFF
--- a/cpp/cmake/StandardConfig.cmake
+++ b/cpp/cmake/StandardConfig.cmake
@@ -185,7 +185,7 @@ function(StandardConfig config_type)
         add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wno-unknown-pragmas>")
         add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:-Werror>" "$<$<COMPILE_LANGUAGE:CUDA>:all-warnings>")
     else()
-        add_compile_options(/W4 /WX /wd4068 /wd4996)
+        add_compile_options(/W4 /WX /EHsc /wd4068 /wd4996)
     endif()
 
     # Enable Format.cmake (https://github.com/provizio/Format.cmake), if ON

--- a/cpp/cmake/StandardConfig.cmake
+++ b/cpp/cmake/StandardConfig.cmake
@@ -185,7 +185,7 @@ function(StandardConfig config_type)
         add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wno-unknown-pragmas>")
         add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:-Werror>" "$<$<COMPILE_LANGUAGE:CUDA>:all-warnings>")
     else()
-        add_compile_options(/W4 /WX /EHsc /wd4068 /wd4996)
+        add_compile_options(/W4 /WX "$<$<COMPILE_LANGUAGE:CXX>:/EHsc>" /wd4068 /wd4996)
     endif()
 
     # Enable Format.cmake (https://github.com/provizio/Format.cmake), if ON


### PR DESCRIPTION
Without /EHsc, MSVC STL headers emit warning C4530 (exception handler used but unwind semantics not enabled), which /WX turns into a compilation error.

See https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4530?view=msvc-170