### PR TITLE
Flatten Conan build layout for consistent VS Code and MSVC builds

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -74,17 +74,20 @@ statement in order to configure conan:
       include(${CMAKE_BINARY_DIR}/Conan.cmake)
      ```
 
-  2. Create a `conanfile.py` in the root directory. The Python format is required
+  2. **Migration note**: If you are upgrading from a previous version of
+     `Conan.cmake` that used `conanfile.txt` or a `conanfile.py` without the
+     flat layout override, you must switch to a `conanfile.py` with the
+     `layout()` override shown below. The old `conanfile.txt` format is no
+     longer supported as it cannot configure the required flat build layout.
+
+     Create a `conanfile.py` in the root directory. The Python format is required
      because `Conan.cmake` expects a flat build layout (`build/generators/`
      instead of `build/Debug/generators/`), which can only be configured by
      overriding `self.folders` in the `layout()` method. Example:
 
      ```Python
-      import os
-
       from conan import ConanFile
       from conan.tools.cmake import cmake_layout
-      from conan.tools.files import copy
 
 
       class ProvizioExample(ConanFile):

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -74,47 +74,40 @@ statement in order to configure conan:
       include(${CMAKE_BINARY_DIR}/Conan.cmake)
      ```
 
-  2. Create conanfile in root directory, example  
-      1. conanfile.py - Python version is more powerful and flexible
+  2. Create a `conanfile.py` in the root directory. The Python format is required
+     because `Conan.cmake` expects a flat build layout (`build/generators/`
+     instead of `build/Debug/generators/`), which can only be configured by
+     overriding `self.folders` in the `layout()` method. Example:
 
-          ```Python
-            import os
+     ```Python
+      import os
 
-            from conan import ConanFile
-            from conan.tools.cmake import cmake_layout
-            from conan.tools.files import copy
+      from conan import ConanFile
+      from conan.tools.cmake import cmake_layout
+      from conan.tools.files import copy
 
 
-            class ProvizioExample(ConanFile):
-                settings = "os", "compiler", "build_type", "arch"
-                generators = "CMakeDeps", "CMakeToolchain"
+      class ProvizioExample(ConanFile):
+          settings = "os", "compiler", "build_type", "arch"
+          generators = "CMakeDeps", "CMakeToolchain"
 
-                def configure(self):
-                    self.options["boost*"].without_test = True
+          def configure(self):
+              self.options["boost*"].without_test = True
 
-                def requirements(self):
-                    self.requires("boost/1.74.0")
-                    self.requires("ms-gsl/4.1.0")
+          def requirements(self):
+              self.requires("boost/1.74.0")
+              self.requires("ms-gsl/4.1.0")
 
-                def layout(self):
-                    cmake_layout(self)
-          ```
-      2. conanfile.txt - txt version is lighter and cleaner
+          def layout(self):
+              cmake_layout(self)
+              # Required: flatten build layout so Conan.cmake finds the toolchain.
+              # Also keeps VS Code CMake presets and manual builds consistent
+              # (single build/ directory, no build/Debug or build/Release subdirs).
+              self.folders.build = "."
+              self.folders.generators = "generators"
+     ```
 
-          ```text
-            [requires]
-            boost/1.74.0
-            ms-gsl/4.1.0
-
-            [generators]
-            CMakeDeps
-            CMakeToolchain
-
-            [layout]
-            cmake_layout
-          ```
-
-  2. Make your CMake projects (libraries and executables) depend on them in standard 'modern cmake style', example:
+  3. Make your CMake projects (libraries and executables) depend on them in standard 'modern cmake style', example:
 
      ```CMake
       find_package(Boost REQUIRED)

--- a/cpp/cmake/Conan.cmake
+++ b/cpp/cmake/Conan.cmake
@@ -28,4 +28,4 @@ if(CONAN_RETURN_CODE AND NOT CONAN_RETURN_CODE EQUAL "0")
     message(FATAL_ERROR "conan install failed: ${CONAN_RETURN_CODE}")
 endif(CONAN_RETURN_CODE AND NOT CONAN_RETURN_CODE EQUAL "0")
 
-set(CMAKE_TOOLCHAIN_FILE "${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/generators/conan_toolchain.cmake")
+set(CMAKE_TOOLCHAIN_FILE "${CMAKE_BINARY_DIR}/generators/conan_toolchain.cmake")

--- a/cpp/cmake/Conan.cmake
+++ b/cpp/cmake/Conan.cmake
@@ -29,3 +29,10 @@ if(CONAN_RETURN_CODE AND NOT CONAN_RETURN_CODE EQUAL "0")
 endif(CONAN_RETURN_CODE AND NOT CONAN_RETURN_CODE EQUAL "0")
 
 set(CMAKE_TOOLCHAIN_FILE "${CMAKE_BINARY_DIR}/generators/conan_toolchain.cmake")
+if(NOT EXISTS "${CMAKE_TOOLCHAIN_FILE}")
+    message(FATAL_ERROR
+        "Expected Conan toolchain file not found at '${CMAKE_TOOLCHAIN_FILE}'. "
+        "Ensure your conanfile.py defines a layout() that flattens generators "
+        "into the 'generators' subdirectory of the CMake build folder. See: "
+        "https://github.com/provizio/coding_standards/blob/master/cpp/README.md#conan")
+endif()


### PR DESCRIPTION
Conan's cmake_layout() for single-config generators (Ninja/Makefiles) creates a build-type subdirectory (e.g. build/Debug/) by default. This causes two problems:

1. VS Code CMake Tools: Conan-generated presets have binaryDir pointing to build/Debug/ instead of build/, causing inconsistent build dirs between manual and preset-based workflows (and recursive nesting on subsequent configures).

2. MSVC multi-config generators: cmake_layout uses flat layout by default, but the toolchain path included ${CMAKE_BUILD_TYPE}/ which does not exist for multi-config generators.

Fix: expect the flat toolchain path (build/generators/conan_toolchain.cmake) in Conan.cmake. Projects must override their conanfile.py layout() to flatten the structure (self.folders.build = ".", self.folders.generators = "generators"). Updated README.md with the required layout override and a note that conanfile.txt cannot support this.