### PR TITLE
cpp/.clang-format: pin SpacesBeforeTrailingComments to 2

### DIFF
--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -1,6 +1,13 @@
 BasedOnStyle: Microsoft
 
 NamespaceIndentation: All
+# Pin SpacesBeforeTrailingComments to 2 so all clang-format versions produce
+# identical output regardless of how the Microsoft base style's defaults drift.
+# Older clang-format (≤13) defaulted this to 2; newer (≥14) defaults to 1.
+# Without this pin a developer on a recent clang-format produces 1-space output
+# locally while CI on an older clang-format flags those same lines for needing
+# 2 spaces — and vice-versa.
+SpacesBeforeTrailingComments: 2
 
 ---
 Language: CSharp


### PR DESCRIPTION
## Summary

- Pin `SpacesBeforeTrailingComments: 2` in `cpp/.clang-format`.

## Why

Different clang-format versions disagree on the Microsoft base style's default for `SpacesBeforeTrailingComments`:
- clang-format ≤ 13: default is `2`
- clang-format ≥ 14: default is `1`

With the rule unpinned, a developer on a recent clang-format produces trailing comments with one space, while CI on an older clang-format insists on two spaces (or vice-versa). `git-clang-format` running in CI then flags the developer's commits as a style violation on lines the developer's local clang-format already considered clean.

Concrete case that triggered this: https://github.com/provizio/apt_gui/actions/runs/26030239754/job/76514005186?pr=172 — local clang-format-18 emitted `} // namespace` (single space), CI's older clang-format flagged it as needing `}  // namespace` (two spaces). The developer's PR was stuck on CI without any way to make local formatting match CI short of installing a matching clang-format binary or editing the downloaded `.clang-format` (which `StandardConfig.cmake` overwrites on every configure).

## Choice of value

I chose `2` rather than `1` because:
- It matches what existing trailing comments in current `provizio/*` repos look like (they were formatted with older toolchains).
- Switching to `1` would generate a project-wide mass-reformat as soon as any consumer upgrades, whereas `2` matches what already exists in committed code on develop branches.

## Effect on downstream consumers

- Developers on clang-format ≤ 13: no change (the value was already 2 by default).
- Developers on clang-format ≥ 14: their `clang-format -i` now produces 2-space trailing comments, matching what CI has been demanding all along. Any 1-space trailing comments they may have authored locally need a single re-format to match.

## Test plan

- [ ] `apt_gui` PR #172 unblocked after bumping `CODING_STANDARDS_VERSION` to a tag that includes this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)