### PR TITLE
fix(cmake): pin downloaded configs to CODING_STANDARDS_VERSION

### DIFF
--- a/cpp/cmake/StandardConfig.cmake
+++ b/cpp/cmake/StandardConfig.cmake
@@ -32,8 +32,18 @@ set(ENABLE_CHECK_FORMAT
   CACHE STRING "Enable Format Checks")
 
 function(StandardConfig config_type)
+  # Pull downloaded configs (.clang-format, .clang-tidy) from the same ref the
+  # consumer pinned via CODING_STANDARDS_VERSION, falling back to master when
+  # unset. Without this, a project that pins CODING_STANDARDS_VERSION still gets
+  # master's configs at configure time, so a master edit silently changes every
+  # consumer's required formatting / tidy checks (non-reproducible builds).
+  if(DEFINED CODING_STANDARDS_VERSION AND CODING_STANDARDS_VERSION)
+    set(_coding_standards_ref "${CODING_STANDARDS_VERSION}")
+  else()
+    set(_coding_standards_ref "master")
+  endif()
   set(CODING_STANDARDS_ROOT
-      "https://raw.githubusercontent.com/provizio/coding_standards/master")
+      "https://raw.githubusercontent.com/provizio/coding_standards/${_coding_standards_ref}")
   set(TLS_VERIFY ON)
 
   # Check the configuration


### PR DESCRIPTION
## Problem

`StandardConfig.cmake` hardcodes the download ref for `.clang-format` and `.clang-tidy` to **`master`**:

```cmake
set(CODING_STANDARDS_ROOT
    "https://raw.githubusercontent.com/provizio/coding_standards/master")
```

So a consumer that pins `CODING_STANDARDS_VERSION` (e.g. `1.10.1`) — and downloads `StandardConfig.cmake` itself from that tag — still receives **master's** `.clang-format`/`.clang-tidy` at configure time. A subsequent edit to those files on `master` then silently changes the required formatting and clang-tidy checks for **every consumer**, regardless of the version they pinned.

This is a reproducibility hole and was the root cause of cross-version clang-format drift in a downstream repo: the committed code matched one config while CI enforced master's (which carried an extra `SpacesBeforeTrailingComments: 2` pin not present in the tagged release).

## Fix

Use the consumer's pinned `CODING_STANDARDS_VERSION` for the config download ref when it is set, falling back to `master` for unpinned consumers (backward compatible). Now pinning the version pins the configs too.

## Compatibility

- Consumers that don't set `CODING_STANDARDS_VERSION` are unaffected (still `master`).
- Consumers that pin it now get matching, reproducible configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)