### PR TITLE
APT-12326: fix .clang-tidy naming and GCC toolchain gaps

### DIFF
--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -68,10 +68,14 @@ CheckOptions:
     value:           lower_case
   - key:             readability-identifier-naming.PrivateMemberCase
     value:           lower_case
+  - key:             readability-identifier-naming.PrivateMemberIgnoredRegexp
+    value:           '[a-z][a-z0-9_]*_'
   - key:             readability-identifier-naming.PrivateMethodCase
     value:           lower_case
   - key:             readability-identifier-naming.ProtectedMemberCase
     value:           lower_case
+  - key:             readability-identifier-naming.ProtectedMemberIgnoredRegexp
+    value:           '[a-z][a-z0-9_]*_'
   - key:             readability-identifier-naming.ProtectedMethodCase
     value:           lower_case
   - key:             readability-identifier-naming.PublicMemberCase

--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -69,13 +69,13 @@ CheckOptions:
   - key:             readability-identifier-naming.PrivateMemberCase
     value:           lower_case
   - key:             readability-identifier-naming.PrivateMemberIgnoredRegexp
-    value:           '[a-z][a-z0-9_]*_'
+    value:           '[a-z][a-z0-9]*(_[a-z0-9]+)*_'
   - key:             readability-identifier-naming.PrivateMethodCase
     value:           lower_case
   - key:             readability-identifier-naming.ProtectedMemberCase
     value:           lower_case
   - key:             readability-identifier-naming.ProtectedMemberIgnoredRegexp
-    value:           '[a-z][a-z0-9_]*_'
+    value:           '[a-z][a-z0-9]*(_[a-z0-9]+)*_'
   - key:             readability-identifier-naming.ProtectedMethodCase
     value:           lower_case
   - key:             readability-identifier-naming.PublicMemberCase

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -69,6 +69,15 @@ clang-tidy analysis can be turned on by providing
 clang-tidy is capable of automatically fixing some of the detected issues: use
 `-DCMAKE_CXX_CLANG_TIDY=clang-tidy;--fix` to enable this mode.
 
+When the compiler is GCC and clang-tidy is 16 or newer, `StandardConfig.cmake`
+also pins clang-tidy to the GCC installation that compiles the code, by adding
+`--extra-arg=--gcc-install-dir=<dir>`. Without this, clang-tidy picks the newest
+GCC on the system rather than the one used for the build, so it can analyse
+against different libstdc++ headers than compilation, or fail to find them at
+all. Images shipping several GCC versions side by side (such as the Jetson
+ones) need it. Pass your own `--gcc-install-dir` in `CMAKE_CXX_CLANG_TIDY` to
+override the detected directory.
+
 ## Conan
 
 Including `StandardConfig.cmake` does not include conan cmake integration since conan2 tries to decouple itself from build tools.  

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -35,6 +35,12 @@ gets the closest to be a standard: Standard Library and
 [Boost](https://www.boost.org/). It's very simple: everything is `lower_case`
 except macros.
 
+Private and protected data members may optionally carry a trailing underscore
+(`config_`, `debug_`) to distinguish them from constructor parameters and local
+variables. This is permitted, not required: both `config_` and `config` are
+accepted, so projects are free to adopt the convention or not. The name must
+still be `lower_case` either way, so `Config_` remains an error.
+
 The formatting style is based on `clang-format`-defined Microsoft style.
 
 ### clang-format

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -39,7 +39,12 @@ Private and protected data members may optionally carry a trailing underscore
 (`config_`, `debug_`) to distinguish them from constructor parameters and local
 variables. This is permitted, not required: both `config_` and `config` are
 accepted, so projects are free to adopt the convention or not. The name must
-still be `lower_case` either way, so `Config_` remains an error.
+still be `lower_case` either way, so `Config_` remains an error. Exactly one
+trailing underscore is allowed: `config__` is still an error.
+
+This exception relies on clang-tidy's `IgnoredRegexp` option, introduced in
+clang-tidy 12. clang-tidy 11 and older silently ignore it and keep rejecting
+`config_`, so use clang-tidy 12 or newer if your project adopts the convention.
 
 The formatting style is based on `clang-format`-defined Microsoft style.
 

--- a/cpp/cmake/StandardConfig.cmake
+++ b/cpp/cmake/StandardConfig.cmake
@@ -120,6 +120,46 @@ function(StandardConfig config_type)
             CACHE STRING "clang-tidy binary and config" FORCE)
     endif()
 
+    # Pin clang-tidy to the same GCC installation that compiles the code. Left to
+    # itself clang-tidy picks the newest GCC on the system, which is not
+    # necessarily the one used for the build - Jetson images routinely ship
+    # several side by side - so analysis can be performed against different
+    # libstdc++ headers than compilation, or fail to find them at all.
+    # --gcc-install-dir is only understood by clang-tidy 18 and newer; older
+    # releases reject it outright, so the version is checked before adding it.
+    # The result is applied as a regular variable rather than to the cache entry
+    # so that repeated configures cannot accumulate duplicate flags.
+    foreach(LANG C CXX)
+        if(CMAKE_${LANG}_CLANG_TIDY AND CMAKE_${LANG}_COMPILER_ID STREQUAL "GNU")
+            list(GET CMAKE_${LANG}_CLANG_TIDY 0 CLANG_TIDY_BINARY)
+            execute_process(
+                COMMAND "${CLANG_TIDY_BINARY}" --version
+                OUTPUT_VARIABLE CLANG_TIDY_VERSION_OUTPUT
+                RESULT_VARIABLE CLANG_TIDY_VERSION_RESULT
+                ERROR_QUIET)
+            execute_process(
+                COMMAND "${CMAKE_${LANG}_COMPILER}" -print-libgcc-file-name
+                OUTPUT_VARIABLE GCC_LIBGCC_FILE
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE GCC_LIBGCC_RESULT
+                ERROR_QUIET)
+            string(REGEX MATCH "LLVM version ([0-9]+)" CLANG_TIDY_VERSION_MATCH
+                "${CLANG_TIDY_VERSION_OUTPUT}")
+            if(CLANG_TIDY_VERSION_RESULT EQUAL 0
+               AND GCC_LIBGCC_RESULT EQUAL 0
+               AND GCC_LIBGCC_FILE
+               AND CLANG_TIDY_VERSION_MATCH
+               AND CMAKE_MATCH_1 GREATER_EQUAL 18)
+                get_filename_component(GCC_INSTALL_DIR "${GCC_LIBGCC_FILE}" DIRECTORY)
+                message(STATUS
+                    "Pinning ${LANG} clang-tidy to GCC installation ${GCC_INSTALL_DIR}")
+                set(CMAKE_${LANG}_CLANG_TIDY
+                    "${CMAKE_${LANG}_CLANG_TIDY};--extra-arg=--gcc-install-dir=${GCC_INSTALL_DIR}"
+                    PARENT_SCOPE)
+            endif()
+        endif(CMAKE_${LANG}_CLANG_TIDY AND CMAKE_${LANG}_COMPILER_ID STREQUAL "GNU")
+    endforeach(LANG C CXX)
+
     # Code Coverage (target 'code_coverage'), to be invoked after running all tests
     if(ENABLE_COVERAGE)
         if(BUILD_TESTING)

--- a/cpp/cmake/StandardConfig.cmake
+++ b/cpp/cmake/StandardConfig.cmake
@@ -127,8 +127,12 @@ function(StandardConfig config_type)
     # libstdc++ headers than compilation, or fail to find them at all.
     # --gcc-install-dir is only understood by clang-tidy 18 and newer; older
     # releases reject it outright, so the version is checked before adding it.
-    # The result is applied as a regular variable rather than to the cache entry
-    # so that repeated configures cannot accumulate duplicate flags.
+    # The first element of CMAKE_<LANG>_CLANG_TIDY is taken to be the clang-tidy
+    # binary; if a wrapper script stands in its place the version probe simply
+    # fails to match and the pin is left unapplied.
+    # The result is applied as a regular variable rather than to the cache entry,
+    # and only if not already present, so that neither repeated configures nor a
+    # nested StandardConfig() call can accumulate duplicate flags.
     foreach(LANG C CXX)
         if(CMAKE_${LANG}_CLANG_TIDY AND CMAKE_${LANG}_COMPILER_ID STREQUAL "GNU")
             list(GET CMAKE_${LANG}_CLANG_TIDY 0 CLANG_TIDY_BINARY)
@@ -151,11 +155,13 @@ function(StandardConfig config_type)
                AND CLANG_TIDY_VERSION_MATCH
                AND CMAKE_MATCH_1 GREATER_EQUAL 18)
                 get_filename_component(GCC_INSTALL_DIR "${GCC_LIBGCC_FILE}" DIRECTORY)
-                message(STATUS
-                    "Pinning ${LANG} clang-tidy to GCC installation ${GCC_INSTALL_DIR}")
-                set(CMAKE_${LANG}_CLANG_TIDY
-                    "${CMAKE_${LANG}_CLANG_TIDY};--extra-arg=--gcc-install-dir=${GCC_INSTALL_DIR}"
-                    PARENT_SCOPE)
+                if(NOT "${CMAKE_${LANG}_CLANG_TIDY}" MATCHES "--gcc-install-dir=")
+                    message(STATUS
+                        "Pinning ${LANG} clang-tidy to GCC installation ${GCC_INSTALL_DIR}")
+                    set(CMAKE_${LANG}_CLANG_TIDY
+                        "${CMAKE_${LANG}_CLANG_TIDY};--extra-arg=--gcc-install-dir=${GCC_INSTALL_DIR}"
+                        PARENT_SCOPE)
+                endif()
             endif()
         endif(CMAKE_${LANG}_CLANG_TIDY AND CMAKE_${LANG}_COMPILER_ID STREQUAL "GNU")
     endforeach(LANG C CXX)

--- a/cpp/cmake/StandardConfig.cmake
+++ b/cpp/cmake/StandardConfig.cmake
@@ -125,14 +125,17 @@ function(StandardConfig config_type)
     # necessarily the one used for the build - Jetson images routinely ship
     # several side by side - so analysis can be performed against different
     # libstdc++ headers than compilation, or fail to find them at all.
-    # --gcc-install-dir is only understood by clang-tidy 18 and newer; older
-    # releases reject it outright, so the version is checked before adding it.
+    # --gcc-install-dir is only understood by clang-tidy 16 and newer; clang-tidy
+    # 15 and older reject it outright ("error: unsupported option"), so the
+    # version is checked before adding it.
     # The first element of CMAKE_<LANG>_CLANG_TIDY is taken to be the clang-tidy
     # binary; if a wrapper script stands in its place the version probe simply
     # fails to match and the pin is left unapplied.
     # The result is applied as a regular variable rather than to the cache entry,
-    # and only if not already present, so that neither repeated configures nor a
-    # nested StandardConfig() call can accumulate duplicate flags.
+    # and only if the flag is not already present, so that neither repeated
+    # configures nor a nested StandardConfig() call can accumulate duplicates.
+    # A --gcc-install-dir supplied explicitly by the user is therefore honoured
+    # rather than overridden, as an explicit setting should be.
     foreach(LANG C CXX)
         if(CMAKE_${LANG}_CLANG_TIDY AND CMAKE_${LANG}_COMPILER_ID STREQUAL "GNU")
             list(GET CMAKE_${LANG}_CLANG_TIDY 0 CLANG_TIDY_BINARY)
@@ -153,7 +156,7 @@ function(StandardConfig config_type)
                AND GCC_LIBGCC_RESULT EQUAL 0
                AND GCC_LIBGCC_FILE
                AND CLANG_TIDY_VERSION_MATCH
-               AND CMAKE_MATCH_1 GREATER_EQUAL 18)
+               AND CMAKE_MATCH_1 GREATER_EQUAL 16)
                 get_filename_component(GCC_INSTALL_DIR "${GCC_LIBGCC_FILE}" DIRECTORY)
                 if(NOT "${CMAKE_${LANG}_CLANG_TIDY}" MATCHES "--gcc-install-dir=")
                     message(STATUS


### PR DESCRIPTION
## Summary

Fixes the `.clang-tidy` / toolchain gaps found in [APT-12326](https://provizio.atlassian.net/browse/APT-12326) while running the pinned `cpp/.clang-tidy` against `radar_processor`.

The ticket listed three gaps. **Two are fixed here. The third does not reproduce and is deliberately not "fixed"** — details below, since that is the part most worth reviewing.

> ⚠️ Both files touched here are downloaded at configure time by **every** consuming project, and `CODING_STANDARDS_VERSION` defaults to `master` — so anything merged ships to the whole fleet immediately. Every claim below was verified by running the real toolchains rather than by inspection.

## 1. Trailing-underscore members (fixed)

Every `readability-identifier-naming.*Case` was set to `lower_case` with no `Suffix` or `IgnoredRegexp` for the member cases, so the config could not express the trailing-underscore convention and reported every such member.

Added `PrivateMemberIgnoredRegexp` / `ProtectedMemberIgnoredRegexp` = `'[a-z][a-z0-9]*(_[a-z0-9]+)*_'`.

This **permits** the underscore rather than **requiring** it, which is the key design decision. `PrivateMemberSuffix: '_'` would have enforced one consistent style — arguably more fitting for a standard — but it would break every existing repo tracking `master`. `IgnoredRegexp` is non-breaking.

The pattern allows **exactly one** trailing underscore. My first version was `'[a-z][a-z0-9_]*_'`, which put `_` inside the repeated class and so also accepted `config___` and `a__b_` — names `master` had correctly flagged. Caught in review and tightened.

Verified with clang-tidy 20.1.0 on x86_64 and aarch64:

| identifier | before | after |
|---|---|---|
| `config_`, `debug_`, `prot_` | flagged ❌ | accepted ✅ |
| `impl_`, `n_items_`, `v4l2_dev_`, `max_range_m_`, `point_cloud_2d_` | flagged ❌ | accepted ✅ |
| `plain_member` | accepted | accepted ✅ |
| `BadName_`, `AlsoBad`, `camelCase_`, `UPPER_`, `_leading` | flagged | flagged ✅ |
| `config___`, `a__b_` | flagged | flagged ✅ |

**One caveat worth knowing:** `IgnoredRegexp` was only added in **clang-tidy 12**. clang-tidy 10 and 11 ignore the option with no diagnostic at all and carry on rejecting `config_` — and 10 is still the default on the Orin NX image. Confirmed against clang-tidy 10 and 11 on the Orin and 13/14/20 locally, and now documented in `cpp/README.md`.

## 2. GCC toolchain pinning (fixed)

clang-tidy selects the *newest* GCC on the system, not the one compiling the code. The Orin NX image ships GCC 8, 9 and 10 side by side, so analysis can run against different libstdc++ headers than compilation. Pointing clang-tidy at GCC 8 on that image gives a hard `'string' file not found`.

`StandardConfig.cmake` now derives the directory from the build's own compiler (`-print-libgcc-file-name`) and passes `--extra-arg=--gcc-install-dir=<dir>`.

Three constraints shaped this:

- **`--gcc-install-dir` needs clang-tidy ≥ 16.** clang-tidy 15 and older fail with `error: unsupported option`, and the *default* `clang-tidy` on the Orin NX is still **version 10** — so adding it unconditionally would have broken builds on that exact device. The version is probed first.

  I originally gated this at 18, which review challenged. Bracketing the boundary directly showed 16 is the real minimum — 15.0.2 rejects the flag, while 16.0.4 accepts *and honours* it (a bogus directory gives `does not contain a GCC installation`, so the driver is genuinely acting on it). Gating at 18 silently skipped the pin on clang-tidy 16 and 17, both in range across the fleet, leaving the very problem this block exists to fix in place. Corrected to 16 and re-verified: 15 unpinned, 16/17/18 pinned, clean build against clang-tidy 16.
- Applied as a regular variable, **not** the cache entry, so repeated `cmake` invocations cannot accumulate duplicates. Confirmed the flag never reaches `CMakeCache.txt`, which also means a pin can never go stale: each configure recomputes it from a clean value.
- The append is skipped when the flag is already present. Without this, a nested `StandardConfig()` call — a standalone sub-project pulled in via `add_subdirectory` — inherited the parent's already-pinned value and appended a second copy. Reproduced against the previous commit (two copies) and fixed (one). The guard sits *after* the version check is evaluated, because CMake's `MATCHES` overwrites `CMAKE_MATCH_1`, which the version check reads.

Gated on `CMAKE_<LANG>_COMPILER_ID STREQUAL "GNU"`, so clang-based builds — including the O-MVLL obfuscation build, which forces clang-17 — are untouched. An explicit user-supplied `--gcc-install-dir` is also left alone.

Verified on the aarch64 Orin NX and locally: flag added with clang-tidy 20 (clean green build, flag present exactly once on the compile line, reaching subdirectory targets), correctly omitted with clang-tidy 10/11, no-op when clang-tidy is off, idempotent across repeated configures *and* nested calls, and no warnings under `cmake -Wdev -Wdeprecated`.

## 3. nlohmann::json crash — not reproducible, no change made

The ticket reported that `cppcoreguidelines-noexcept-destructor` hits infinite recursion in `ExceptionSpecAnalyzer::analyze()` on `nlohmann::json`, silently producing zero diagnostics. I could not reproduce this, and I don't think a workaround belongs in the shared config. Three hypotheses were tested:

| Hypothesis | Toolchain | Result |
|---|---|---|
| clang-tidy 20 segfault | clang-tidy 20.1.0, x86_64 + aarch64, nlohmann 3.11.3 + 3.12.0 | **refuted** |
| ASan/UBSan/LSan/TSan | GCC 10, x86_64 + aarch64 | clean |
| O-MVLL obfuscation build | clang-17 + O-MVLL, CUDA 12.6, aarch64 | clean |

**Why refuted rather than merely unreproduced:** given a class with a `nlohmann::json` member *and* a throwing destructor — the shape that forces `ExceptionSpecAnalyzer` to walk nlohmann's templated serializer destructor — the check **fires correctly**. The analyzer is not recursing on `nlohmann::json`.

**What most likely produced the original observation:** the check's only trigger is a dynamic exception specification (`~s() throw(int)`). That is a *hard error* under C++17, which `StandardConfig.cmake` pins. So the check cannot fire on any conforming Provizio C++17 code — it reports zero diagnostics on a json-including TU for the same reason it reports zero on any other TU. That looks exactly like a silent failure but isn't one.

Runs on json-including TUs consistently generated 120k–151k warnings with real diagnostics and clean exits — no crash, hang, or silent zero.

Disabling the check would therefore cost real coverage to work around a bug that isn't there, so the config is unchanged. Full negative result recorded on the ticket.

The obfuscation angle was also tested on the real toolchain with `radar_processor`'s own `omvll_config.py`: a heavy nlohmann workload (exception paths, 200-deep nesting, 20k-element arrays, CBOR/MessagePack/BSON round-trips, `json_pointer`, iterators, stream parse) ran **byte-identical to the control**, with obfuscation verifiably applied. If a crash does exist there it is O-MVLL configuration in `radar_processor`, not anything in this repo.

## Note: the stale `google-runtime-references` exclusion stays

`--verify-config` reports `unknown check 'google-runtime-references'` on modern clang-tidy, because the check was removed in LLVM 16. It looks like dead config, but **removing the exclusion would be a regression**, so I've left it:

- The check still exists in clang-tidy 11 and earlier (verified: present in LLVM 11, absent in LLVM 20).
- Dropping the `-google-runtime-references` exclusion means `'*'` enables it there, and it flags *every* non-const reference parameter — verified: `void fill(std::vector<int> &out)` produces `non-const reference parameter 'out', make it const or use a pointer`.
- With `WarningsAsErrors: '*'`, that is a hard build failure on exactly the older toolchains this repo still has to support.

So it has to stay until those toolchains are retired. The `--verify-config` warning is cosmetic and does not affect normal runs. Flagging it here so it isn't mistaken for staleness and "cleaned up" later.

## Worth knowing before merging: both fixes are inert on the Orin NX as imaged

Neither fix does anything on the device the ticket came from, because both need a clang-tidy newer than that image's default of **10** (only 10 and 11 are installed):

| Fix | Needs | Below that version |
|---|---|---|
| Trailing-underscore members (`IgnoredRegexp`) | clang-tidy **12+** | option silently ignored — `config_` still reported |
| GCC pinning (`--gcc-install-dir`) | clang-tidy **16+** | flag not added (version-gated, so nothing breaks) |

Both fail safe, so merging is harmless there — it just has no effect until a newer clang-tidy is on the device (`pip install clang-tidy==<ver>` in a venv works on aarch64). Flagging it so the outcome isn't a surprise.

## Testing

This repo has no CI or test harness, so verification was manual against the exact toolchain from the ticket — clang-tidy 10/11/13/14/18/20 as relevant, on x86_64 and aarch64, plus CMake configure/build matrices on the Orin NX and the AGX Orin. Specific results are in each commit message.

Copilot review was unavailable (quota exhausted — it posted only its quota notice), so the review pass was run locally instead; the third commit is the result.

[APT-12326]: https://provizio.atlassian.net/browse/APT-12326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
